### PR TITLE
fix: add start script and port config for DigitalOcean deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm run start

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",
+    "start": "vite preview --port 8080",
     "type-check": "tsc --noEmit",
     "test": "vitest"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     open: true
   },
   preview: {
-    port: 4173,
+    port: +(process.env.PORT || 8080),
     host: true
   }
 });


### PR DESCRIPTION
## Summary
- add start script to run `vite preview` on port 8080
- configure preview server to use `$PORT` or 8080
- add Procfile calling `npm run start` for deployment

## Testing
- `npm test` *(fails: Error when mocking module, missing dependency)*
- `npm run lint` *(fails: 224 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689b1525bf448321a8c17e3abd67ee51